### PR TITLE
Add modes for printing the formatted post to STDOUT

### DIFF
--- a/raffle.py
+++ b/raffle.py
@@ -29,6 +29,8 @@ def parse_args(parser):
             "dump-base64-picked-object",
             "post-data-to-topic",
             "post-winners-to-topic",
+            "print-data",
+            "print-winners",
         ],
         help="What action to take.",
     )
@@ -171,5 +173,10 @@ def main():
             discouse_connection.make_post(args.topic_id, libs.discourse_helper.generate_post_data(all_items))
         case 'post-winners-to-topic':
             discouse_connection.make_post(args.topic_id, libs.discourse_helper.generate_post_winners(all_items))
+        case 'print-data':
+            print(libs.discourse_helper.generate_post_data(all_items))
+        case 'print-winners':
+            print(libs.discourse_helper.generate_post_winners(all_items))
+
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
The modes `post-data-to-topic` and `post-winners-to-topic` format the output and post it directly to Discourse as the RaffleBot user.

I've added corresponding modes to do the same formatting, but just dump it to STDOUT.