### PR TITLE
fix: match uppercase X in quantity regex and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,4 +23,9 @@ To run the RaffleBot as a github action, you need:
 2. the raffle post's topicID - e.g. talk.vanhack.ca/t/raffle-welcome-to-2021/11292/18 the ID is 11292
 3. an action `print-nice`, `dump-raw-object`, `dump-base64-picked-object`, `post-data-to-topic`, `post-winners-to-topic`, `print-raw-data-post`, or  `print-raw-winners-post`
 
-To run the rafflebot locally, you need a everything above, plus a discourse api key.
+To run the rafflebot locally, you need everything above, plus a discourse api key.
+
+Example:
+```bash
+python raffle.py print-nice 11292 --api-key <YOUR_API_KEY>
+```

--- a/raffle.py
+++ b/raffle.py
@@ -28,7 +28,7 @@ info = logger.info
 warn = logger.warn
 err = logger.error
 
-description_re = "^((\d+) ?[x*] )?<?\w+.+"
+description_re = r"^((\d+) ?[xX*] )?<?\w+.+"
 
 
 def parse_args(parser):


### PR DESCRIPTION
## Summary
Fixes regex pattern to match uppercase 'X' in quantity prefixes (e.g., "2X keyboards") and adds local testing documentation.

## Changes
- Updated regex character class from `[x*]` to `[xX*]` to handle both uppercase and lowercase
- Converted pattern to raw string literal (`r"..."`) following best practices
- Added testing instructions to README with example

## Testing
Tested locally on latest raffle with:
```bash
python raffle.py print-nice 16870 --api-key <API_KEY>
```
Verified that posts with uppercase quantity prefixes (e.g., "5X item") are now parsed correctly.

## Issue
Fixes  the issue described here https://talk.vanhack.ca/t/february-2026-super-raffle/16870/7